### PR TITLE
Fixing Install Script Typo & adding Conda Install Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,15 @@ An archive containing Python packages and an installation script can be download
 
 - Alternatively, download the archive file from the [releases](https://github.com/apple/tensorflow_macos/releases). The archive contains an installation script, accelerated versions of TensorFlow, TensorFlow Addons, and needed dependencies.
 
-#### Notes
+#### Conda
+Alternatively, you can download Miniforge Python (which has the Conda package manager) and install TensorFlow on it.
+
+1. Download a Python 3.8 for Apple Silicon ARM from https://github.com/conda-forge/miniforge/#download and install it.
+2. [Optional] Create a Python 3.8 Conda Environment for TensorFlow
+3. Download the archive file from the [releases](https://github.com/apple/tensorflow_macos/releases)
+4. Run `scripts/install_venv.sh --prompt` and at the prompt, provide the path to your environment's directory. For example: `~/miniforge3/envs/tensorflow` if your env name is `tensorflow` and you installed Miniforge ot your home directory.
+
+#### Notes/Users/Matthew/miniforge3/envs/tensorflow
 
 For Macs with M1, the following packages are currently unavailable:
 


### PR DESCRIPTION
## Update

As of 02/02/2021, Apple has updated this copy of TensorFlow. I have created a Conda Environment File to make it easier to install TensorFlow to MiniForge (not Anaconda -- Anaconda is not ARM compatible). Instructions on how to do this are tentatively posted on: https://github.com/apple/tensorflow_macos/issues/153

---

## Original PR

Hello there,

I'd like to propose this PR to address two issues:

1. There is a typo right now where $virtual_env has two forms of capitalization in the installation script that's causing pip to crash during installation
2. By removing the check for finding `bin/activate` for Python and being more clever with when we need to activate it (i.e. only when we're using a virtual env), we can make the installation script work for Conda/Miniforge installs. I also added documentation to Readme.md about how one can install Tensorflow on Conda if they'd like.